### PR TITLE
 industrias estratégicas del estado

### DIFF
--- a/CPEUM/025.rst
+++ b/CPEUM/025.rst
@@ -29,7 +29,7 @@ desarrollo de la Nación.
 El sector público tendrá a su cargo, de manera exclusiva, las áreas
 estratégicas que se señalan en el artículo 28, párrafo cuarto de la
 Constitución, manteniendo siempre el Gobierno Federal la propiedad y el
-control sobre los organismos y empresas productivas del Estado que en su
+control sobre los organismos y empresas públicas del Estado que en su
 caso se establezcan. Tratándose de la planeación y el control del
 sistema eléctrico nacional, y del servicio público de transmisión y
 distribución de energía eléctrica, así como de la exploración y
@@ -38,11 +38,11 @@ dichas actividades en términos de lo dispuesto por los párrafos sexto y
 séptimo del artículo 27 de esta Constitución. En las actividades citadas
 la ley establecerá las normas relativas a la administración,
 organización, funcionamiento, procedimientos de contratación y demás
-actos jurídicos que celebren las empresas productivas del Estado, así
-como el régimen de remuneraciones de su personal, para garantizar su
+actos jurídicos que celebren las empresas públicas del Estado, así como
+el régimen de remuneraciones de su personal, para garantizar su
 eficacia, eficiencia, honestidad, productividad, transparencia y
-rendición de cuentas, con base en las mejores prácticas, y determinará
-las demás actividades que podrán realizar.
+rendición de cuentas, y determinará las demás actividades que podrán
+realizar.
 
 Asimismo podrá participar por sí o con los sectores social y privado, de
 acuerdo con la ley, para impulsar y organizar las áreas prioritarias del

--- a/CPEUM/027.rst
+++ b/CPEUM/027.rst
@@ -93,14 +93,16 @@ concesiones, y su inobservancia dará lugar a la cancelación de éstas. El
 Gobierno Federal tiene la facultad de establecer reservas nacionales y
 suprimirlas. Las declaratorias correspondientes se harán por el
 Ejecutivo en los casos y condiciones que las leyes prevean. Tratándose
-de minerales radiactivos no se otorgarán concesiones. Corresponde
-exclusivamente a la Nación la planeación y el control del sistema
-eléctrico nacional, así como el servicio público de transmisión y
-distribución de energía eléctrica; en estas actividades no se otorgarán
-concesiones, sin perjuicio de que el Estado pueda celebrar contratos con
-particulares en los términos que establezcan las leyes, mismas que
-determinarán la forma en que los particulares podrán participar en las
-demás actividades de la industria eléctrica.
+de minerales radiactivos y litio no se otorgarán concesiones.
+Corresponde exclusivamente a la Nación la planeación y el control del
+sistema eléctrico nacional en los términos del artículo 28 de esta
+Constitución, así como el servicio público de transmisión y distribución
+de energía eléctrica; en estas actividades no se otorgarán concesiones.
+Las leyes determinarán la forma en que los particulares podrán
+participar en las demás actividades de la industria eléctrica, que en
+ningún caso tendrán prevalencia sobre la empresa pública del Estado,
+cuya esencia es cumplir con su responsabilidad social y garantizar la
+continuidad y accesibilidad del servicio público de electricidad.
 
 Tratándose del petróleo y de los hidrocarburos sólidos, líquidos o
 gaseosos, en el subsuelo, la propiedad de la Nación es inalienable e
@@ -108,10 +110,10 @@ imprescriptible y no se otorgarán concesiones. Con el propósito de
 obtener ingresos para el Estado que contribuyan al desarrollo de largo
 plazo de la Nación, ésta llevará a cabo las actividades de exploración y
 extracción del petróleo y demás hidrocarburos mediante asignaciones a
-empresas productivas del Estado o a través de contratos con éstas o con
+empresas públicas del Estado o a través de contratos con éstas o con
 particulares, en los términos de la Ley Reglamentaria. Para cumplir con
-el objeto de dichas asignaciones o contratos las empresas productivas
-del Estado podrán contratar con particulares. En cualquier caso, los
+el objeto de dichas asignaciones o contratos las empresas públicas del
+Estado podrán contratar con particulares. En cualquier caso, los
 hidrocarburos en el subsuelo son propiedad de la Nación y así deberá
 afirmarse en las asignaciones o contratos.
 

--- a/CPEUM/028.rst
+++ b/CPEUM/028.rst
@@ -28,20 +28,26 @@ mejor cuidado de sus intereses.
 
 No constituirán monopolios las funciones que el Estado ejerza de manera
 exclusiva en las siguientes áreas estratégicas: correos, telégrafos y
-radiotelegrafía; minerales radiactivos y generación de energía nuclear;
-la planeación y el control del sistema eléctrico nacional, así como el
-servicio público de transmisión y distribución de energía eléctrica, y
-la exploración y extracción del petróleo y de los demás hidrocarburos,
-en los términos de los párrafos sexto y séptimo del artículo 27 de esta
-Constitución, respectivamente; así como las actividades que expresamente
-señalen las leyes que expida el Congreso de la Unión. La comunicación
-vía satélite y los ferrocarriles, tanto para transporte de pasajeros
-como de carga, son áreas prioritarias para el desarrollo nacional en los
-términos del artículo 25 de esta Constitución; el Estado al ejercer en
-ellas su rectoría, protegerá la seguridad y la soberanía de la Nación, y
-al otorgar asignaciones, concesiones o permisos mantendrá o establecerá
-el dominio de las respectivas vías de comunicación de acuerdo con las
-leyes de la materia.
+radiotelegrafía; minerales radiactivos, litio y generación de energía
+nuclear; el servicio de Internet que provea el Estado; la planeación y
+el control del sistema eléctrico nacional, cuyos objetivos serán
+preservar la seguridad y autosuficiencia energética de la Nación y
+proveer al pueblo de la electricidad al menor precio posible, evitando
+el lucro, para garantizar la seguridad nacional y soberanía a través de
+la empresa pública del Estado que se establezca; así como el servicio
+público de transmisión y distribución de energía eléctrica, y la
+exploración y extracción del petróleo y de los demás hidrocarburos, en
+los términos de los párrafos sexto y séptimo del artículo 27 de esta
+Constitución, respectivamente; así como las actividades que realicen las
+empresas públicas del Estado y las que expresamente señalen las leyes
+que expida el Congreso de la Unión. La comunicación vía satélite y los
+ferrocarriles, tanto para transporte de pasajeros como de carga, son
+áreas prioritarias para el desarrollo nacional en los términos del
+artículo 25 de esta Constitución; el Estado al ejercer en ellas su
+rectoría, protegerá la seguridad y la soberanía de la Nación, y al
+otorgar asignaciones, concesiones o permisos mantendrá o establecerá el
+dominio de las respectivas vías de comunicación de acuerdo con las leyes
+de la materia.
 
 El Estado Mexicano retoma el derecho de utilizar las vías ferroviarias
 para prestar el servicio de transporte de pasajeros. Para ello, el

--- a/CPEUM/T262.rst
+++ b/CPEUM/T262.rst
@@ -1,0 +1,19 @@
+**Primero**
+
+El presente Decreto entrará en vigor al día siguiente de su publicación
+en el Diario Oficial de la Federación.
+
+**Segundo**
+
+El Congreso de la Unión tendrá un plazo de ciento ochenta días naturales
+a partir de la entrada en vigor del presente Decreto para realizar las
+adecuaciones que resulten necesarias a las leyes secundarias
+correspondientes, en los términos de este.
+
+**Tercero**
+
+Se derogan los artículos Transitorios del Decreto por el que se reforman
+y adicionan diversas disposiciones de la Constitución Política de los
+Estados Unidos Mexicanos, en Materia de Energía publicado en el Diario
+Oficial de la Federación el veinte de diciembre de dos mil trece, que se
+opongan a las disposiciones materia del presente Decreto.

--- a/CPEUM/toc.rst
+++ b/CPEUM/toc.rst
@@ -2338,3 +2338,13 @@ quinto al artículo 28 de la Constitución Política de los Estados Unidos
 Mexicanos, en materia de vías y transporte ferroviario.
 
 .. include:: T261.rst
+
+Artículos Transitorios de Decretos de Reforma (262)
+---------------------------------------------------
+
+DECRETO por el que se reforman el párrafo quinto del artículo 25, los
+párrafos sexto y séptimo del artículo 27 y el párrafo cuarto del
+artículo 28 de la Constitución Política de los Estados Unidos Mexicanos,
+en materia de áreas y empresas estratégicas.
+
+.. include:: T262.rst


### PR DESCRIPTION
Artículo 25, 27 y 28

http://sil.gobernacion.gob.mx/Archivos/Documentos/2024/02/asun_4696970_20240205_1707785855.pdf

DECRETO por el que se reforman los artículos 25, 27 y 28 de la Constitución Política de los Estados Unidos Mexicanos en materia de industrias estratégicas del estado:

Artículo Único.- Se reforman los párrafos quinto del artículo 25; párrafo sexto del artículo 27; y párrafo cuarto del artículo 28, todos de la Constitución Política de los Estados Unidos Mexicanos, para quedar como sigue: