### PR TITLE
inimpugnabilidad de las adiciones o reformas a la Constitución

### DIFF
--- a/CPEUM/105.rst
+++ b/CPEUM/105.rst
@@ -146,3 +146,7 @@ XVI del artículo 107 de esta Constitución.
 Tratándose de controversias constitucionales o de acciones de
 inconstitucionalidad planteadas respecto de normas generales, en ningún
 caso su admisión dará lugar a la suspensión de la norma cuestionada.
+
+Son improcedentes las controversias constitucionales o acciones de
+inconstitucionalidad que tengan por objeto controvertir las adiciones o
+reformas a esta Constitución.

--- a/CPEUM/107.rst
+++ b/CPEUM/107.rst
@@ -24,6 +24,8 @@ II. Las sentencias que se pronuncien en los juicios de amparo sólo se
     especial sobre el que verse la demanda. Tratándose de juicios de
     amparo que resuelvan la inconstitucionalidad de normas generales, en
     ningún caso las sentencias que se dicten fijarán efectos generales.
+    No procederá el juicio de amparo contra adiciones o reformas a esta
+    Constitución.
 
     Cuando en los juicios de amparo indirecto en revisión se resuelva la
     inconstitucionalidad de una norma general, la Suprema Corte de

--- a/CPEUM/T263.rst
+++ b/CPEUM/T263.rst
@@ -1,0 +1,9 @@
+**Primero**
+
+El presente Decreto entrará en vigor al día siguiente de su publicación
+en el Diario Oficial de la Federación.
+
+**Segundo**
+
+Los asuntos que se encuentren en trámite deberán resolverse conforme a
+las disposiciones contenidas en el presente Decreto.

--- a/CPEUM/toc.rst
+++ b/CPEUM/toc.rst
@@ -2348,3 +2348,13 @@ artículo 28 de la Constitución Política de los Estados Unidos Mexicanos,
 en materia de áreas y empresas estratégicas.
 
 .. include:: T262.rst
+
+Artículos Transitorios de Decretos de Reforma (263)
+---------------------------------------------------
+
+DECRETO por el que se reforma el primer párrafo de la fracción II del
+artículo 107, y se adiciona un quinto párrafo al artículo 105, de la
+Constitución Política de los Estados Unidos Mexicanos, en materia de
+inimpugnabilidad de las adiciones o reformas a la Constitución Federal.
+
+.. include:: T263.rst


### PR DESCRIPTION
DECRETO por el que se reforma el primer párrafo de la fracción II del artículo 107, y se adiciona un quinto párrafo al artículo 105, de la Constitución Política de los Estados Unidos Mexicanos, en materia de inimpugnabilidad de las adiciones o reformas a la Constitución Federal.

Presidenta Claudia Sheinbaum Pardo

Publicado en el Diario Oficial de la Federación el 31 de octubre del 2024 https://dof.gob.mx/nota_detalle.php?codigo=5742105&fecha=31/10/2024

Se reforma:

+ el primer párrafo de la fracción II del artículo 107

Se adiciona:

+ un quinto párrafo al artículo 105