### PR TITLE
ci: mejoras al workflow de BlueSky

### DIFF
--- a/.github/workflows/bluesky.yaml
+++ b/.github/workflows/bluesky.yaml
@@ -17,22 +17,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Check if last commit in PR contains document changes
+      - name: Check if PR contains document changes
+        id: check
         run: |
-          git show --name-only --oneline HEAD | head -1 | grep -i -e "artículo" -e "articulo"
-          git show --name-only --oneline HEAD | tail -n +2 | grep "^CPEUM/.*\.rst$"
+          SUBJECT=$(git log -1 --format=%s HEAD)
+          FILES=$(git show --name-only --format='' HEAD | grep "^CPEUM/.*\.rst$" || true)
 
-      - name: Extract second paragraph of commit log if previous step was successful
-        if: success()
+          if echo "$SUBJECT" | grep -qi -e "artículo" -e "articulo" && [ -n "$FILES" ]; then
+            echo "document_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "document_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract commit description
+        if: steps.check.outputs.document_changes == 'true'
         id: desc
         run: |
-          git show --summary --format=%B HEAD | awk -v RS='(\r?\n){2,}' 'NR == 2 { print "desc=" $RS }' | sed ':a;N;$!ba;s/\n/ /g' >> "$GITHUB_OUTPUT"
+          git log -1 --format=%B HEAD | awk -v RS='' 'NR == 2' | sed ':a;N;$!ba;s/\n/ /g' | awk '{print "desc=" $0}' >> "$GITHUB_OUTPUT"
 
-      # Announce merge of the pull request in BlueSky
       - name: Post in BlueSky
-        if: success()
+        if: steps.check.outputs.document_changes == 'true'
         uses: zentered/bluesky-post-action@v0.2.0
         with:
           post: |


### PR DESCRIPTION
El workflow de BlueSky se disparaba en cada merge a main, independientemente de si el PR contenía cambios a artículos de la constitución o no. Esto ocurría porque los pasos de verificación no producían fallo ante una ausencia de coincidencias, y los pasos siguientes usaban `if: success()`, que se evaluaba como verdadero en todos los casos.

Además, la detección del subject del commit usaba `head -1`, lo que cortaba subjects que ocuparan más de una línea, y la extracción del cuerpo del mensaje usaba `RS='(\r?\n){2,}'` y referenciaba `$RS` en lugar del contenido del párrafo, produciendo una descripción vacía.

Se reemplazó la lógica de verificación por un paso con id `check` que compara el subject completo del commit y los archivos .rst modificados bajo CPEUM/, y expone un output booleano `document_changes`. Los pasos subsiguientes ahora condicionan su ejecución a ese output en lugar de `success()`. También se corrigió la extracción del cuerpo del commit usando `RS=''` (paragraph mode) y se emigró de `git show` a `git log` para mayor claridad.