### PR TITLE
Artículos 115, 116 y 134

### DIFF
--- a/CPEUM/115.rst
+++ b/CPEUM/115.rst
@@ -6,20 +6,22 @@ base de su división territorial y de su organización política y
 administrativa, el municipio libre, conforme a las bases siguientes:
 
 I. Cada Municipio será gobernado por un Ayuntamiento de elección popular
-   directa, integrado por un Presidente o Presidenta Municipal y el
-   número de regidurías y sindicaturas que la ley determine, de
-   conformidad con el principio de paridad. En ningún caso, podrá
-   participar en la elección para la presidencia municipal, las
-   regidurías y las sindicaturas, la persona que tenga o haya tenido en
-   los últimos tres años anteriores al día de la elección un vínculo de
-   matrimonio o concubinato o unión de hecho, o de parentesco por
-   consanguinidad o civil en línea recta sin limitación de grado y en
-   línea colateral hasta el cuarto grado o de afinidad hasta el segundo
-   grado, con la persona que esté ejerciendo la titularidad del cargo
-   para el que se postula. La competencia que esta Constitución otorga
-   al gobierno municipal se ejercerá por el Ayuntamiento de manera
-   exclusiva y no habrá autoridad intermedia alguna entre este y el
-   gobierno del Estado.
+   directa, integrado por un Presidente o Presidenta Municipal, una
+   sindicatura y hasta quince regidurías, de conformidad con los
+   principios de paridad de género vertical y horizontal, perspectiva de
+   género e igualdad sustantiva en el acceso, integración y ejercicio
+   del poder público municipal. En ningún caso, podrá participar en la
+   elección para la presidencia municipal, las regidurías y las
+   sindicaturas, la persona que tenga o haya tenido en los últimos tres
+   años anteriores al día de la elección un vínculo de matrimonio o
+   concubinato o unión de hecho, o de parentesco por consanguinidad o
+   civil en línea recta sin limitación de grado y en línea colateral
+   hasta el cuarto grado o de afinidad hasta el segundo grado, con la
+   persona que esté ejerciendo la titularidad del cargo para el que se
+   postula. La competencia que esta Constitución otorga al gobierno
+   municipal se ejercerá por el Ayuntamiento de manera exclusiva y no
+   habrá autoridad intermedia alguna entre este y el gobierno del
+   Estado.
 
    Las Constituciones de los Estados deberán establecer la prohibición
    de la reelección consecutiva para el mismo cargo de presidentes y

--- a/CPEUM/116.rst
+++ b/CPEUM/116.rst
@@ -53,21 +53,26 @@ II. El número de representantes en las legislaturas de los Estados será
     exceda de este número y no llegue a 800 mil habitantes, y de 11 en
     los Estados cuya población sea superior a esta última cifra.
 
-    Las Constituciones estatales deberán establecer la prohibición de la
-    reelección de las personas diputadas a las legislaturas de los
-    Estados para el periodo inmediato posterior al ejercicio de su
-    mandato. Las personas diputadas suplentes podrán ser electas para el
-    periodo inmediato con el carácter de propietarias, siempre que no
-    hubieren estado en ejercicio, pero las personas diputadas
-    propietarias no podrán ser electas para el período inmediato con el
-    carácter de suplentes. En ningún caso, podrá participar en la
-    elección de una diputación la persona que tenga o haya tenido en los
-    últimos tres años anteriores al día de la elección un vínculo de
-    matrimonio o concubinato o unión de hecho, o de parentesco por
-    consanguinidad o civil en línea recta sin limitación de grado y en
-    línea colateral hasta el cuarto grado o de afinidad hasta el segundo
-    grado, con la persona que está ejerciendo la titularidad de la
-    diputación.
+    Las Constituciones estatales deberán establecer que el presupuesto
+    anual de las legislaturas locales no exceda del cero punto setenta
+    por ciento del presupuesto de egresos de la entidad federativa
+    correspondiente. Asimismo, deberán garantizar los principios de
+    paridad, igualdad sustantiva y perspectiva de género, en la
+    integración y funcionamiento de los órganos legislativos locales;
+    así como prohibir la reelección de las personas diputadas a las
+    legislaturas de los Estados para el periodo inmediato posterior al
+    ejercicio de su mandato. Las personas diputadas suplentes podrán ser
+    electas para el periodo inmediato con el carácter de propietarias,
+    siempre que no hubieren estado en ejercicio, pero las personas
+    diputadas propietarias no podrán ser electas para el período
+    inmediato con el carácter de suplentes. En ningún caso, podrá
+    participar en la elección de una diputación la persona que tenga o
+    haya tenido en los últimos tres años anteriores al día de la
+    elección un vínculo de matrimonio o concubinato o unión de hecho, o
+    de parentesco por consanguinidad o civil en línea recta sin
+    limitación de grado y en línea colateral hasta el cuarto grado o de
+    afinidad hasta el segundo grado, con la persona que está ejerciendo
+    la titularidad de la diputación.
 
     Las legislaturas de los Estados se integrarán con diputados electos,
     según los principios de mayoría relativa y de representación

--- a/CPEUM/134.rst
+++ b/CPEUM/134.rst
@@ -19,6 +19,19 @@ republicana, eliminando todo tipo de duplicidades funcionales u
 organizacionales, atendiendo a las necesidades de mejora y modernización
 de la gestión pública.
 
+Las remuneraciones de las personas consejeras electorales, las
+magistradas y magistrados electorales, titulares de las secretarías de
+órganos administrativos y titulares de áreas ejecutivas y técnicas u
+homólogos del Instituto Nacional Electoral, los organismos públicos
+locales electorales y los tribunales electorales de las entidades
+federativas, no excederán el límite establecido en el artículo 127 de
+esta Constitución y no podrán adquirir o contratar con recursos públicos
+seguros de gastos médicos, de vida o de pensiones privadas, seguros de
+separación individualizados, cajas de ahorro especiales, regímenes
+especiales de retiro u otras prestaciones que no estén previstas por la
+ley, decreto, disposición general, contrato colectivo o condiciones
+generales de trabajo.
+
 Las adquisiciones, arrendamientos y enajenaciones de todo tipo de
 bienes, prestación de servicios de cualquier naturaleza y la
 contratación de obra que realicen, se adjudicarán o llevarán a cabo a

--- a/CPEUM/T281.rst
+++ b/CPEUM/T281.rst
@@ -1,0 +1,118 @@
+**Primero**
+
+El presente Decreto entrará en vigor el día siguiente al de su
+publicación en el Diario Oficial de la Federación.
+
+**Segundo**
+
+El Congreso de la Unión y las legislaturas de las entidades federativas,
+en el ámbito de su competencia, armonizarán su marco jurídico para
+adecuarlo al contenido del presente Decreto a más tardar el 30 de mayo
+de 2026.
+
+Entre tanto, se aplicarán en lo conducente de manera directa las
+disposiciones constitucionales en la materia y, supletoriamente, las
+leyes en materia electoral en todo lo que no se contraponga al presente
+Decreto.
+
+**Tercero**
+
+A partir del ejercicio fiscal inmediato siguiente a la entrada en vigor
+del presente Decreto, el presupuesto anual autorizado para el Senado de
+la República deberá ajustarse de manera progresiva durante los cuatro
+ejercicios fiscales subsecuentes, con el objeto de alcanzar, al término
+de dicho periodo, una reducción acumulada equivalente al quince por
+ciento en términos reales, respecto del presupuesto base vigente para el
+ejercicio fiscal 2026. La reducción no podrá afectar los derechos
+laborales de las personas trabajadoras, conforme a las Condiciones
+Generales de Trabajo aplicables.
+
+**Cuarto**
+
+El Instituto Nacional Electoral, los organismos públicos locales
+electorales y los tribunales electorales de las entidades federativas
+revisarán y adecuarán sus disposiciones normativas, administrativas y
+presupuestarias para garantizar el cumplimiento de lo previsto en el
+presente Decreto.
+
+La Cámara de Diputados y las legislaturas de las entidades federativas,
+en el ámbito de su competencia, garantizarán que los presupuestos de los
+entes públicos y autoridades electorales federales y de las entidades
+federativas se ajusten a lo previsto en los artículos 116 y 134
+constitucionales, por lo que realizarán en cada ejercicio fiscal los
+ajustes necesarios a los presupuestos que integren, previo a su
+aprobación.
+
+**Quinto**
+
+Las legislaturas de las entidades federativas preverán los ajustes
+necesarios a sus presupuestos con el objeto de que las reducciones que,
+en su caso, se realicen en cumplimiento a lo previsto en el artículo 116
+Constitucional, surtan efectos a partir del inicio de la legislatura
+subsecuente en la entidad federativa que corresponda.
+
+La Cámara de Diputados, en el Presupuesto de Egresos que corresponda,
+hará los ajustes necesarios para dar cumplimiento al contenido de este
+Decreto, por lo que se refiere a congresos de las entidades federativas
+y ayuntamientos.
+
+**Sexto**
+
+La integración de los Ayuntamientos establecida en lo dispuesto en el
+artículo 115 constitucional surtirá efectos a partir del periodo
+administrativo municipal subsecuente en la entidad federativa que
+corresponda.
+
+Los Ayuntamientos que, a la entrada en vigor del presente Decreto,
+cuenten con un número de regidurías menor a quince, conservarán su
+integración actual. Solo en los casos que se requiera alguna
+modificación de la integración por criterios de variación poblacional u
+otros requisitos, se realizará conforme a lo establecido en las
+constituciones y leyes de las entidades federativas.
+
+**Séptimo**
+
+Los recursos públicos que resulten como economías o ahorros en los
+presupuestos anuales de las entidades federativas derivados de las
+reducciones que, en su caso, se realicen a los presupuestos de las
+legislaturas locales y en la integración de los Ayuntamientos conforme a
+los artículos 115 y 116 constitucionales, quedarán en el patrimonio de
+la hacienda pública de cada municipio. Las legislaturas de las entidades
+federativas destinarán estos recursos excedentes a obras de
+infraestructura pública en beneficio de la población dentro del
+presupuesto correspondiente, en los términos de la legislación
+aplicable, garantizando en todo momento los principios de legalidad,
+honradez, transparencia y austeridad.
+
+**Octavo**
+
+Las entidades federativas cuyas legislaturas, a la entrada en vigor del
+presente Decreto, cuenten con un presupuesto anual que represente un
+porcentaje igual o menor al límite previsto en el artículo 116 de esta
+Constitución, no podrán autorizar, aprobar o ejercer para sí mismas
+incrementos presupuestarios reales respecto del monto aprobado para el
+ejercicio fiscal 2026, ni incrementar dicha proporción respecto del
+presupuesto de egresos de la entidad federativa correspondiente en los
+ejercicios fiscales subsecuentes.
+
+El monto del presupuesto anual de los Congresos de las entidades
+federativas únicamente podrá actualizarse conforme a la inflación anual.
+
+No podrán aprobar ampliaciones presupuestarias, transferencias,
+reasignaciones, adecuaciones presupuestarias, reclasificaciones
+administrativas o cualquier otro mecanismo que tenga por objeto o efecto
+incrementar directamente el presupuesto de los Congresos locales por
+encima del límite previsto en el presente transitorio.
+
+Las constituciones y leyes de las entidades federativas deberán
+armonizarse con lo dispuesto en este transitorio y establecer los
+mecanismos institucionales de control, disciplina presupuestaria y
+responsabilidad administrativa necesarios para asegurar su cumplimiento.
+
+Cualquier disposición, determinación presupuestaria o acto de autoridad
+que contravenga lo establecido en el presente transitorio será nulo de
+pleno derecho.
+
+**Noveno**
+
+Se derogan las disposiciones que se opongan al presente Decreto.

--- a/CPEUM/toc.rst
+++ b/CPEUM/toc.rst
@@ -2516,3 +2516,13 @@ Constitución Política de los Estados Unidos Mexicanos, en Materia de
 Límite A las Jubilaciones y Pensiones de las Entidades Públicas.
 
 .. include:: T280.rst
+
+Artículos Transitorios de Decretos de Reforma (281)
+---------------------------------------------------
+
+DECRETO por el que se Reforman los Artículos 115, Fracción I, Párrafo
+Primero, y 116, Fracción II, Párrafo Segundo, y se Adiciona al Artículo
+134, un Párrafo Cuarto, Recorriéndose los Subsecuentes en su Orden, de
+la Constitución Política de los Estados Unidos Mexicanos.
+
+.. include:: T281.rst

--- a/es-local.dic
+++ b/es-local.dic
@@ -1,4 +1,4 @@
-personal_ws-1.1 es 435 utf-8
+personal_ws-1.1 es 438 utf-8
 acuacultura
 adolfo
 aduanales
@@ -32,6 +32,7 @@ anticorrupción
 aprehenderse
 aranda
 archivarse
+armonizarse
 arnulfo
 arteaga
 asignatarios
@@ -304,6 +305,7 @@ pluriculturalidad
 plurinominal
 plurinominales
 plutarco
+poblacional
 politica
 ponérsele
 porfirio
@@ -332,6 +334,7 @@ ramírez
 rancherías
 readscriban
 readscritos
+reasignaciones
 reasignación
 recabarse
 recibírsele


### PR DESCRIPTION
DECRETO por el que se reforman los artículos 115, fracción I, párrafo primero, y 116, fracción II, párrafo segundo, y se adiciona al artículo 134, un párrafo cuarto, recorriéndose los subsecuentes en su orden, de la Constitución Política de los Estados Unidos Mexicanos.

Presidenta Claudia Sheinbaum Pardo

Publicado en el Diario Oficial de la Federación el 23 de abril del 2026 https://dof.gob.mx/nota_detalle.php?codigo=5785817&fecha=23/04/2026

Se reforman:

+ Artículo 115, fracción I, párrafo primero
+ Artículo 116, fracción II, párrafo segundo

Se adiciona:

+ Artículo 134, un párrafo cuarto, recorriéndose los subsecuentes en su orden