### PR TITLE
scripts: rst2html5: no levantar error en unimplemented_visit()

### DIFF
--- a/scripts/rst2html5.py
+++ b/scripts/rst2html5.py
@@ -227,9 +227,7 @@ class CustomHTMLTranslator(HTMLTranslator):
             HTMLTranslator.depart_container(self, node)
 
     def unimplemented_visit(self, node):
-        raise NotImplementedError(
-            f"visiting unimplemented node type: {node.__class__.__name__}"
-        )
+        pass
 
 
 class CustomHTML5Writer(Writer):


### PR DESCRIPTION
De lo contrario no se generan los <aside> con los cambios constitucionales.