### PR TITLE
Artículo 41

### DIFF
--- a/CPEUM/041.rst
+++ b/CPEUM/041.rst
@@ -572,6 +572,9 @@ VI. Para garantizar los principios de constitucionalidad y legalidad de
     c. Se reciban o utilicen recursos de procedencia ilícita o recursos
        públicos en las campañas.
 
+    d. Se acrediten actos de intervención o injerencia extranjera que
+       influyan en los resultados electorales.
+
     Dichas violaciones deberán acreditarse de manera objetiva y
     material. Se presumirá que las violaciones son determinantes cuando
     la diferencia entre la votación obtenida entre el primero y el

--- a/CPEUM/T284.rst
+++ b/CPEUM/T284.rst
@@ -1,0 +1,19 @@
+**Primero**
+
+El presente Decreto entrará en vigor el día siguiente al de su
+publicación en el Diario Oficial de la Federación.
+
+**Segundo**
+
+El Congreso de la Unión y las legislaturas de las entidades federativas,
+en el ámbito de su competencia, deberán armonizar el marco normativo
+para adecuarlo al contenido de este Decreto, antes del 5 de junio
+de 2026.
+
+**Tercero**
+
+El Instituto Nacional Electoral, los organismos públicos locales
+electorales, el Tribunal Electoral del Poder Judicial de la Federación y
+los tribunales electorales de las entidades federativas revisarán y
+adecuarán sus disposiciones normativas y administrativas para garantizar
+el cumplimiento de lo previsto en el presente Decreto.

--- a/CPEUM/toc.rst
+++ b/CPEUM/toc.rst
@@ -2544,3 +2544,13 @@ Constitución Política de los Estados Unidos Mexicanos, en materia de
 reforma al Poder Judicial.
 
 .. include:: T283.rst
+
+Artículos Transitorios de Decretos de Reforma (284)
+---------------------------------------------------
+
+DECRETO por el que se adiciona un inciso a la base VI del artículo 41 de
+la Constitución Política de los Estados Unidos Mexicanos, para
+introducir una nueva causal de nulidad de elecciones por intervención
+extranjera.
+
+.. include:: T284.rst


### PR DESCRIPTION
DECRETO por el que se adiciona un inciso a la base VI del artículo 41 de la Constitución Política de los Estados Unidos Mexicanos, para introducir una nueva causal de nulidad de elecciones por intervención extranjera.

Presidenta Claudia Sheinbaum Pardo

Publicado en el Diario Oficial de la Federación el 2 de junio del 2016 https://dof.gob.mx/nota_detalle.php?codigo=5789358&fecha=02/06/2026

Se adiciona:

+ Artículo 41, un inciso de) al párrafo tercero de la base VI