### PR TITLE
Agregar run.sh para compilar y servir el sitio CPEUM localmente

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+##########
+# Compilar y servir el sitio CPEUM localmente
+##########
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/scripts"
+HTML_DIR="${SCRIPT_DIR}/html"
+
+# Paso 1: Compilar el sitio
+echo "==> Compilando sitio..."
+cd "${SCRIPT_DIR}/CPEUM"
+uv run "${SCRIPTS_DIR}/rst2html5.py" toc.rst "${HTML_DIR}/index.html"
+
+# Paso 2: Iniciar servidor HTTP en segundo plano
+echo "==> Iniciando servidor HTTP en puerto 8000..."
+cd "${HTML_DIR}"
+python3 -m http.server 8000 &
+SERVER_PID=$!
+echo "==> PID del servidor: ${SERVER_PID}"
+
+# Limpiar al salir
+trap 'echo "==> Deteniendo servidor..."; kill ${SERVER_PID} 2>/dev/null' EXIT
+
+# Paso 3: Abrir navegador
+sleep 0.5
+xdg-open http://127.0.0.1:8000
+
+# Esperar al proceso del servidor
+wait "${SERVER_PID}"


### PR DESCRIPTION
Automatiza el ciclo de compilación y visualización del sitio para agilizar el desarrollo y la revisión de cambios.

Ejecuta en secuencia: compila toc.rst a HTML con rst2html5.py mediante uv, levanta un servidor HTTP en segundo plano sobre el directorio html, y abre el navegador en 127.0.0.1:8000. Al finalizar limpia el proceso servidor con una trap EXIT.