### PR TITLE
docutils: corregir configuración

### DIFF
--- a/CPEUM/docutils.conf
+++ b/CPEUM/docutils.conf
@@ -1,9 +1,7 @@
-[global]
-toc-top-backlinks: yes
-verbose: yes
-strict: yes
-date: yes
-time: yes
+[general]
+strict_visitor: yes
+datestamp: %Y-%m-%d %H:%M UTC
+language_code: es
 
 [html writers]
 embed_stylesheet: yes

--- a/css/cpeum.css
+++ b/css/cpeum.css
@@ -3,6 +3,7 @@ body {
 	margin: 0;
 	padding: 0;
 	display: flex;
+	flex-direction: column;
 	min-height: 100vh;
 	font-family: Georgia, "Noto Serif", "DejaVu Serif", serif;
 	line-height: 1.6;
@@ -90,6 +91,13 @@ nav.contents a:hover {
 	background: #e0e0e0;
 }
 
+/* Footer */
+footer {
+	margin-left: 300px;
+	padding: 20px;
+	box-sizing: border-box;
+}
+
 /* Mobile responsive styles */
 @media (max-width: 768px) {
 	body {
@@ -106,7 +114,8 @@ nav.contents a:hover {
 		border-bottom: 1px solid #ddd;
 	}
 
-	main {
+	main,
+	footer {
 		margin-left: 0;
 		padding: 20px;
 	}

--- a/css/minimal.css
+++ b/css/minimal.css
@@ -382,6 +382,9 @@ header {
 footer {
 	border-top: 1px solid black;
 }
+footer p {
+	text-align: right;
+}
 
 /* Images are block-level by default in Docutils */
 /* New HTML5 block elements: set display for older browsers */


### PR DESCRIPTION
La configuración especificada en docutils.conf no era la correcta.

Además se añade en al final del documento (footer), alineado a la derecha, la fecha y hora de generación del documento.