### PR TITLE
css: corregir advertencias de noDescendingSpecificity de biome

### DIFF
--- a/css/cpeum.css
+++ b/css/cpeum.css
@@ -113,7 +113,7 @@ aside.sidebar ul {
 	padding-left: 15px;
 }
 
-aside.sidebar li {
+aside.sidebar :where(li) {
 	margin-bottom: 5px;
 }
 
@@ -131,7 +131,7 @@ nav.contents ul {
 	padding-left: 20px;
 }
 
-nav.contents li {
+nav.contents :where(li) {
 	margin-bottom: 5px;
 }
 
@@ -182,13 +182,6 @@ footer {
 		margin-left: 0;
 		padding: 16px;
 	}
-}
-
-/* Show the main title and initial content */
-main > h1.title,
-main > p,
-main > section:first-of-type {
-	display: block;
 }
 
 /* Hide all other sections by default (single-page article viewer) */
@@ -333,4 +326,11 @@ section:is(.articulo, [id^="articulos-transitorios"]):target {
 		font-size: 0.8em;
 		text-align: center;
 	}
+}
+
+/* Show the main title and initial content */
+main > h1.title,
+main > p,
+main > section:first-of-type {
+	display: block;
 }

--- a/css/minimal.css
+++ b/css/minimal.css
@@ -70,6 +70,11 @@ span.problematic {
 	white-space: pre-wrap;
 }
 
+/* Footer text is right-aligned */
+footer p {
+	text-align: right;
+}
+
 /* Lists */
 
 /* compact and simple lists: no margin between items */
@@ -381,9 +386,6 @@ header {
 }
 footer {
 	border-top: 1px solid black;
-}
-footer p {
-	text-align: right;
 }
 
 /* Images are block-level by default in Docutils */


### PR DESCRIPTION
Se reordenaroon selectores en css/minimal.css y css/cpeum.css para eliminar las 4 advertencias de biome del tipo lint/style/ noDescendingSpecificity.

La regla exige que, a lo largo de una hoja de estilos, los selectores no bajen de especificidad respecto de los que ya aparecieron antes (de lo contrario se pierde la jerarquía predecible del cascada y una regla posterior débil podría quedar anulada de forma no intencionada).

- cpeum.css: se envuelven los selectores 'aside.sidebar li' y 'nav.contents li' con :where(), porque ambos contenedores quedan ocultos en la impresión (@media print) y ninguna regla posterior compite por sus márgenes; y se traslada el bloque 'main > h1.title, main > p, main > section:first-of-type' al final del archivo para que no quede antes que las reglas tipográficas genéricas p/li del bloque de impresión.

- minimal.css: se ubica la regla 'footer p' antes de la sección Lists, donde quedaba por debajo de los selectores .simple > li p.